### PR TITLE
Add Emby

### DIFF
--- a/infra/emby/Apply-Namespace.ps1
+++ b/infra/emby/Apply-Namespace.ps1
@@ -1,0 +1,5 @@
+
+
+kubectl apply -f emby-config.yaml
+kubectl apply -f media-volume.yaml
+kubectl apply -f emby-deploy.yaml

--- a/infra/emby/emby-config.yaml
+++ b/infra/emby/emby-config.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: emby-config
+  namespace: emby
+data:
+  config-system.xml: |
+    <?xml version="1.0"?>
+    <ServerConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <EnableDebugLevelLogging>false</EnableDebugLevelLogging>
+      <EnableAutoUpdate>true</EnableAutoUpdate>
+      <LogFileRetentionDays>3</LogFileRetentionDays>
+      <RunAtStartup>true</RunAtStartup>
+      <IsStartupWizardCompleted>false</IsStartupWizardCompleted>
+      <EnableUPnP>true</EnableUPnP>
+      <PublicPort>8096</PublicPort>
+      <PublicHttpsPort>8920</PublicHttpsPort>
+      <HttpServerPortNumber>8096</HttpServerPortNumber>
+      <HttpsPortNumber>8920</HttpsPortNumber>
+      <EnableHttps>false</EnableHttps>
+      <IsPortAuthorized>true</IsPortAuthorized>
+      <AutoRunWebApp>true</AutoRunWebApp>
+      <EnableRemoteAccess>true</EnableRemoteAccess>
+      <LogAllQueryTimes>false</LogAllQueryTimes>
+      <EnableCaseSensitiveItemIds>true</EnableCaseSensitiveItemIds>
+      <PreferredMetadataLanguage>en</PreferredMetadataLanguage>
+      <MetadataCountryCode>US</MetadataCountryCode>
+      <SortRemoveWords>
+        <string>the</string>
+        <string>a</string>
+        <string>an</string>
+        <string>das</string>
+        <string>der</string>
+        <string>el</string>
+        <string>la</string>
+      </SortRemoveWords>
+      <LibraryMonitorDelay>60</LibraryMonitorDelay>
+      <EnableDashboardResponseCaching>true</EnableDashboardResponseCaching>
+      <ImageSavingConvention>Compatible</ImageSavingConvention>
+      <EnableAutomaticRestart>true</EnableAutomaticRestart>
+      <CollectionFolderIdsMigrated>false</CollectionFolderIdsMigrated>
+      <UICulture>en-us</UICulture>
+      <SaveMetadataHidden>false</SaveMetadataHidden>
+      <RemoteClientBitrateLimit>0</RemoteClientBitrateLimit>
+      <DisplaySpecialsWithinSeasons>true</DisplaySpecialsWithinSeasons>
+      <LocalNetworkSubnets />
+      <LocalNetworkAddresses />
+      <EnableExternalContentInSuggestions>true</EnableExternalContentInSuggestions>
+      <RequireHttps>false</RequireHttps>
+      <IsBehindProxy>false</IsBehindProxy>
+      <RemoteIPFilter />
+      <IsRemoteIPFilterBlacklist>false</IsRemoteIPFilterBlacklist>
+      <ImageExtractionTimeoutMs>0</ImageExtractionTimeoutMs>
+      <PathSubstitutions />
+      <UninstalledPlugins />
+      <CollapseVideoFolders>true</CollapseVideoFolders>
+      <EnableOriginalTrackTitles>false</EnableOriginalTrackTitles>
+      <VacuumDatabaseOnStartup>false</VacuumDatabaseOnStartup>
+      <SimultaneousStreamLimit>0</SimultaneousStreamLimit>
+      <DatabaseCacheSizeMB>96</DatabaseCacheSizeMB>
+      <EnableSqLiteMmio>false</EnableSqLiteMmio>
+      <NextUpUpgraded>false</NextUpUpgraded>
+      <ChannelOptionsUpgraded>false</ChannelOptionsUpgraded>
+      <TimerIdsUpgraded>false</TimerIdsUpgraded>
+      <ForcedSortNameUpgraded>false</ForcedSortNameUpgraded>
+      <InheritedParentalRatingValueUpgraded>false</InheritedParentalRatingValueUpgraded>
+      <EnablePeopleLetterSubFolders>false</EnablePeopleLetterSubFolders>
+      <OptimizeDatabaseOnShutdown>true</OptimizeDatabaseOnShutdown>
+      <DatabaseAnalysisLimit>400</DatabaseAnalysisLimit>
+      <DisableAsyncIO>false</DisableAsyncIO>
+    </ServerConfiguration>

--- a/infra/emby/emby-deploy.yaml
+++ b/infra/emby/emby-deploy.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: emby
+  labels:
+    app: emby
+  namespace: emby
+spec:
+  ports:
+    - port: 8920
+      protocol: TCP
+      targetPort: 8920
+      name: https
+    - port: 8096
+      protocol: TCP
+      targetPort: 8096
+      name: http
+  selector:
+    app: emby
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: emby
+  labels:
+    app: emby
+  namespace: emby
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: emby
+  template:
+    metadata:
+      labels:
+        app: emby
+    spec:
+      containers:
+        - name: emby
+          image: emby/embyserver:latest
+          ports:
+            - containerPort: 8096
+            - containerPort: 8920
+          volumeMounts:
+            #- name: emby-config
+            #  mountPath: /config/config/system.xml
+            #  subPath: config-system.xml
+            - name: emby-data
+              mountPath: /mnt/emby-data
+      volumes:
+        - name: emby-config
+          configMap:
+            name: emby-config
+        - name: emby-data
+          persistentVolumeClaim:
+            claimName: emby-media-claim

--- a/infra/emby/emby-ingress.yaml
+++ b/infra/emby/emby-ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: emby
+  namespace: emby
+  annotations:
+    cert-manager.io/cluster-issuer: dyrvold-dev-zerossl
+spec:
+  ingressClassName: public
+  rules:
+    - host: emby.dyrvold.dev
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: emby
+                port:
+                  name: http
+    - host: emby
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: emby
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - "emby.dyrvold.dev"
+      secretName: emby-cert

--- a/infra/emby/media-volume.yaml
+++ b/infra/emby/media-volume.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: emby-media-claim
+  namespace: emby
+  labels:
+    app: emby
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 500Gi
+  volumeName: "emby-media-volume"
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: emby-media-volume
+  namespace: emby
+  labels:
+    app: emby
+spec:
+  claimRef:
+    namespace: emby
+    name: emby-media-claim
+  storageClassName: manual
+  capacity:
+    storage: 500Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/home/k8s-emby"


### PR DESCRIPTION
Emby is cool for hosting media for viewing from server to chromecast for instance. 
At this stage there is still a problem with a certain level of volatility. On container restart the server requires setup both auth and pointer to media directory.